### PR TITLE
Rename workspace packages to match pnpm filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+pnpm-lock.yaml
+dist
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 # AI Fashion Studio
 
-Monorepo con:
+Monorepo per il progetto **AI Fashion Studio** composto da frontend React/Vite e backend Node/Express.
 
-- **web/** → frontend React + Vite
-- **server/** → backend Node + Express
+## Requisiti
+
+- Node.js 18+
+- pnpm 8+
+
+## Setup
+
+```bash
+pnpm install
+```
 
 ## Avvio
 
+Avviare i servizi in due terminali separati:
+
 ```bash
-# installa dipendenze
-pnpm install
-
-# avvia frontend
-cd web && pnpm dev
-
-# avvia backend
-cd server && pnpm dev
+pnpm --filter web dev
+pnpm --filter server dev
 ```
+
+- Frontend disponibile su [http://localhost:5173](http://localhost:5173)
+- Backend disponibile su [http://localhost:3001/api/health](http://localhost:3001/api/health)
+
+Entrambi gli ambienti utilizzano variabili in `.env` (non versionate) per configurare le rispettive API.
+
+### Variabili d'ambiente
+
+- `web/.env`: configurare `VITE_API_BASE` se il backend non gira su `/api`.
+- `server/.env`: opzionale `GEMINI_API_KEY=<la tua chiave API Gemini>` (oppure `GOOGLE_API_KEY`).
+  - Se la chiave è presente il backend userà il modello **Gemini 2.5 Flash Image Preview**.
+  - In assenza della chiave il server avvierà automaticamente un adattatore mock locale, permettendo di provare il flusso senza chiamate esterne.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ai-fashion-studio",
+  "private": true,
+  "version": "0.1.0"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - web
+  - server

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
+    "start": "node build/index.js",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@google/genai": "^0.5.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "dotenv": "^16.4.5",
+    "p-queue": "^8.0.1",
+    "undici": "^6.19.8",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "nodemon": "^3.1.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,6 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@google/genai": "^0.5.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "dotenv": "^16.4.5",

--- a/server/src/adapter/GeminiModelAdapter.ts
+++ b/server/src/adapter/GeminiModelAdapter.ts
@@ -1,0 +1,472 @@
+import { ImageModelAdapter } from "./ImageModelAdapter";
+import {
+  AnalyzeResponseSchema,
+  AssignSlotsResponseSchema,
+  ClothingCategory,
+  GenerateResponseSchema,
+  InputSlot,
+  NEGATIVE_PROMPT,
+  Shot,
+  VariantCombination,
+  VariantReferences,
+  VariantResponseSchema
+} from "../schemas";
+import { fetch } from "undici";
+
+const GEMINI_MODEL = "gemini-2.5-flash-image-preview";
+const BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const JSON_ATTEMPTS = 2;
+
+const ANALYZE_SCHEMA_SHAPE =
+  '{"categories": ClothingCategory[], "confidence": number (0-1), "notes"?: string}';
+const ASSIGN_SCHEMA_SHAPE =
+  '{"slots": {"front"?: number, "side"?: number, "back"?: number, "detail"?: number}}';
+
+const ANALYZE_SYSTEM_PROMPT = `You are a senior fashion product classifier. Inspect garments precisely and output strict JSON.
+Categories available:
+- Top maniche corte: short-sleeved tops or t-shirts stopping above elbow.
+- Top maniche lunghe: tops or shirts with sleeves covering the forearm.
+- Maglia: knitted sweaters or pullovers.
+- Felpa: hoodies or sweatshirts with ribbed cuffs or hood.
+- Giacca: structured outerwear like blazers, trenches, leather jackets.
+- Pantalone: trousers, jeans, leggings covering the legs individually.
+- Gonna: skirts covering lower body without separating legs.
+- Abito: one-piece dresses joining top and bottom; do not also label as top+bottom.
+Rules: choose only what is visible. Dresses supersede tops/skirts. If uncertain use notes and reduce confidence.
+Few-shot guidance:
+- Example 1 (Felpa vs Giacca): Input shows a soft sweatshirt with ribbed cuffs and kangaroo pocket. Output -> {"categories":["Felpa"],"confidence":0.9,"notes":"Zip hoodie, not a jacket"}.
+- Example 2 (Abito vs combinazione top+gonna): Input shows a single-piece dress with continuous fabric from bodice to skirt. Output -> {"categories":["Abito"],"confidence":0.92}.
+- Example 3 (Giacca): Input shows a structured blazer layered over a blouse. Output -> {"categories":["Giacca","Top maniche lunghe"],"confidence":0.88,"notes":"Blazer over shirt"}.
+Return ONLY JSON matching ${ANALYZE_SCHEMA_SHAPE}.`;
+
+const ASSIGN_SYSTEM_PROMPT = `Assign garment photos to canonical slots. Exactly match JSON schema ${ASSIGN_SCHEMA_SHAPE}.
+Guidelines:
+- Front shows the outfit from the front.
+- Side shows a profile view.
+- Back shows the garment from behind.
+- Detail shows close-ups of materials or accessories.
+Prefer the clearest option when duplicates exist. Leave slots undefined if image missing.`;
+
+const GENERATION_SYSTEM_PROMPT = `You are an expert AI fashion photographer. Produce editorial, high consistency imagery following reference photos, maintaining garment proportions, identity and styling cues.`;
+
+const VARIANT_SYSTEM_PROMPT = `You generate fashion color and print variants. Keep poses, lighting and styling aligned with the anchor while applying requested variant accents precisely.`;
+
+type Part =
+  | { text: string }
+  | { inlineData: { data: string; mimeType: string } };
+
+type Content = {
+  role: "user" | "model" | "system";
+  parts: Part[];
+};
+
+type GenerationConfig = {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseModalities?: ("TEXT" | "IMAGE")[];
+};
+
+type GeminiResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Part[];
+    };
+    finishReason?: string;
+  }>;
+  promptFeedback?: {
+    blockReason?: string;
+  };
+};
+
+const sanitizeJson = (raw: string) =>
+  raw
+    .trim()
+    .replace(/^```json\s*/i, "")
+    .replace(/^```\s*/i, "")
+    .replace(/```$/i, "")
+    .trim();
+
+const extractText = (response: GeminiResponse): string => {
+  const candidate = response.candidates?.[0];
+  if (!candidate?.content?.parts?.length) {
+    throw new Error("Gemini response missing text candidate");
+  }
+  return candidate.content.parts
+    .filter((part): part is { text: string } => "text" in part && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+};
+
+const extractInlineImages = (response: GeminiResponse) => {
+  const candidate = response.candidates?.[0];
+  if (!candidate?.content?.parts) {
+    throw new Error("Gemini response missing image candidate");
+  }
+  return candidate.content.parts
+    .filter((part): part is { inlineData: { data: string; mimeType: string } } =>
+      "inlineData" in part && !!part.inlineData?.data
+    )
+    .map((part) => part.inlineData);
+};
+
+const detectMimeType = (base64: string): string => {
+  const buffer = Buffer.from(base64, "base64");
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return "image/png";
+};
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "variant";
+
+export class GeminiModelAdapter implements ImageModelAdapter {
+  private readonly apiKey: string;
+
+  constructor(apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY) {
+    if (!apiKey) {
+      throw new Error("GEMINI_API_KEY (or GOOGLE_API_KEY) environment variable is required");
+    }
+    this.apiKey = apiKey;
+  }
+
+  private async generateContent(
+    body: {
+      systemInstruction?: Content;
+      contents: Content[];
+      generationConfig?: GenerationConfig;
+    },
+    signal?: AbortSignal
+  ): Promise<GeminiResponse> {
+    const response = await fetch(
+      `${BASE_URL}/models/${GEMINI_MODEL}:generateContent?key=${this.apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal
+      }
+    );
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Gemini API error (${response.status}): ${errorBody.slice(0, 400)}`
+      );
+    }
+
+    const json = (await response.json()) as GeminiResponse;
+    if (json.promptFeedback?.blockReason) {
+      throw new Error(`Gemini blocked the prompt: ${json.promptFeedback.blockReason}`);
+    }
+    if (!json.candidates?.length) {
+      throw new Error("Gemini returned no candidates");
+    }
+    return json;
+  }
+
+  private buildImageParts(
+    header: string,
+    images: Array<{ label: string; base64: string }>
+  ): Part[] {
+    const parts: Part[] = [{ text: header }];
+    images.forEach(({ label, base64 }) => {
+      parts.push({ text: label });
+      parts.push({ inlineData: { data: base64, mimeType: detectMimeType(base64) } });
+    });
+    return parts;
+  }
+
+  private async generateJsonWithRetries<T>(
+    params: {
+      systemPrompt: string;
+      baseParts: Part[];
+      schema: { parse: (value: unknown) => T };
+      schemaShape: string;
+    },
+    signal?: AbortSignal
+  ): Promise<T> {
+    let extraInstruction = "";
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < JSON_ATTEMPTS; attempt += 1) {
+      const parts = [...params.baseParts];
+      if (extraInstruction) {
+        parts.push({ text: extraInstruction });
+      }
+
+      const response = await this.generateContent(
+        {
+          systemInstruction: {
+            role: "system",
+            parts: [{ text: params.systemPrompt }]
+          },
+          contents: [
+            {
+              role: "user",
+              parts
+            }
+          ],
+          generationConfig: {
+            temperature: 0.2,
+            maxOutputTokens: 600,
+            responseModalities: ["TEXT"]
+          }
+        },
+        signal
+      );
+
+      try {
+        const text = sanitizeJson(extractText(response));
+        const json = JSON.parse(text);
+        return params.schema.parse(json);
+      } catch (error) {
+        lastError = error as Error;
+        extraInstruction = `The previous response was invalid JSON. Respond again with ONLY valid JSON adhering to ${params.schemaShape}.`;
+      }
+    }
+
+    throw new Error(
+      `Unable to parse Gemini JSON response after ${JSON_ATTEMPTS} attempts: ${lastError?.message}`
+    );
+  }
+
+  async analyze(imageBase64: string, signal?: AbortSignal) {
+    const baseParts: Part[] = [
+      ...this.buildImageParts(
+        "Classify the primary garment categories present in this image.",
+        [
+          {
+            label: "Garment reference image:",
+            base64: imageBase64
+          }
+        ]
+      )
+    ];
+
+    return this.generateJsonWithRetries(
+      {
+        systemPrompt: ANALYZE_SYSTEM_PROMPT,
+        baseParts,
+        schema: AnalyzeResponseSchema,
+        schemaShape: ANALYZE_SCHEMA_SHAPE
+      },
+      signal
+    );
+  }
+
+  async assignSlots(images: string[], signal?: AbortSignal) {
+    const labelled = images.map((base64, index) => ({
+      label: `Image ${index + 1}:`,
+      base64
+    }));
+
+    const parts = this.buildImageParts(
+      "Assign each reference to front, side, back or detail.",
+      labelled
+    );
+
+    return this.generateJsonWithRetries(
+      {
+        systemPrompt: ASSIGN_SYSTEM_PROMPT,
+        baseParts: parts,
+        schema: AssignSlotsResponseSchema,
+        schemaShape: ASSIGN_SCHEMA_SHAPE
+      },
+      signal
+    );
+  }
+
+  async generate(
+    params: {
+      shot: Shot;
+      slots: Partial<Record<InputSlot, string>>;
+      confirmedCategories: ClothingCategory[];
+      correctivePrompts: string[];
+      anchorImage?: string;
+    },
+    signal?: AbortSignal
+  ) {
+    const { shot, slots, confirmedCategories, correctivePrompts, anchorImage } = params;
+
+    const parts: Part[] = [
+      {
+        text: [
+          `Create a high fidelity fashion photograph for shot "${shot.description}" (category: ${shot.shot_category}).`,
+          `Confirmed garments: ${confirmedCategories.join(", ") || "nessuna"}.`,
+          `Prompt template: ${shot.prompt_template}.`,
+          correctivePrompts.length
+            ? `Incorporate corrective prompts: ${correctivePrompts.join("; ")}.`
+            : "No corrective prompts provided.",
+          "Maintain consistent identity, pose, lighting and background with references.",
+          `Avoid: ${NEGATIVE_PROMPT}.`
+        ].join("\n")
+      }
+    ];
+
+    const referenceImages: Array<{ label: string; base64: string }> = [];
+    if (anchorImage) {
+      referenceImages.push({
+        label: "Anchor shot for identity and styling:",
+        base64: anchorImage
+      });
+    }
+
+    Object.entries(slots).forEach(([slot, base64]) => {
+      if (!base64) return;
+      referenceImages.push({
+        label: `Reference for slot ${slot}:`,
+        base64
+      });
+    });
+
+    if (referenceImages.length) {
+      parts.push(...this.buildImageParts("Reference imagery:", referenceImages));
+    }
+
+    const response = await this.generateContent(
+      {
+        systemInstruction: {
+          role: "system",
+          parts: [{ text: GENERATION_SYSTEM_PROMPT }]
+        },
+        contents: [
+          {
+            role: "user",
+            parts
+          }
+        ],
+        generationConfig: {
+          temperature: 0.35,
+          responseModalities: ["IMAGE"],
+          maxOutputTokens: 1024
+        }
+      },
+      signal
+    );
+
+    const [image] = extractInlineImages(response);
+    if (!image) {
+      throw new Error("Gemini did not return an image for generation request");
+    }
+
+    return GenerateResponseSchema.parse({ imageBase64: image.data });
+  }
+
+  async generateVariant(
+    params: {
+      combination: VariantCombination;
+      anchorImage: string;
+      references: VariantReferences;
+    },
+    signal?: AbortSignal
+  ) {
+    const productList = Object.keys(params.references ?? {}) as ClothingCategory[];
+    const variantName = params.combination.name || "Variant";
+
+    const description = [
+      `Create a color/print variant for ${variantName}.`,
+      productList.length
+        ? `Products to adjust: ${productList.join(", ")}.`
+        : "Adjust garments consistently using creative judgement.",
+      "Retain fit, proportions, lighting and background continuity from the anchor image.",
+      `Avoid: ${NEGATIVE_PROMPT}.`
+    ].join("\n");
+
+    const parts: Part[] = [
+      { text: description },
+      ...this.buildImageParts("Anchor image:", [
+        {
+          label: "Anchor reference:",
+          base64: params.anchorImage
+        }
+      ])
+    ];
+
+    const referenceEntries = Object.entries(params.references ?? {}) as Array<[
+      ClothingCategory,
+      string
+    ]>;
+
+    if (referenceEntries.length) {
+      parts.push(
+        ...this.buildImageParts(
+          "Color and print references per garment:",
+          referenceEntries.map(([category, base64]) => ({
+            label: `${category} reference:`,
+            base64
+          }))
+        )
+      );
+    }
+
+    const response = await this.generateContent(
+      {
+        systemInstruction: {
+          role: "system",
+          parts: [{ text: VARIANT_SYSTEM_PROMPT }]
+        },
+        contents: [
+          {
+            role: "user",
+            parts
+          }
+        ],
+        generationConfig: {
+          temperature: 0.4,
+          responseModalities: ["IMAGE"],
+          maxOutputTokens: 1024
+        }
+      },
+      signal
+    );
+
+    const [image] = extractInlineImages(response);
+    if (!image) {
+      throw new Error("Gemini did not return an image for variant request");
+    }
+
+    const filename = `OUTFIT-${slugify(params.combination.id)}_${slugify(
+      variantName
+    )}_${productList.map((product) => slugify(product)).join("-") || "look"}.jpg`;
+
+    return VariantResponseSchema.parse([
+      {
+        imageBase64: image.data,
+        filename,
+        products: productList.length ? productList : ["Outfit"],
+        variantName
+      }
+    ]);
+  }
+}

--- a/server/src/adapter/ImageModelAdapter.ts
+++ b/server/src/adapter/ImageModelAdapter.ts
@@ -1,0 +1,33 @@
+import {
+  AnalyzeResponseSchema,
+  AssignSlotsResponseSchema,
+  ClothingCategory,
+  GenerateResponseSchema,
+  InputSlot,
+  Shot,
+  VariantCombination,
+  VariantReferences,
+  VariantResponseSchema
+} from "../schemas";
+
+type AnalyzeResult = ReturnType<typeof AnalyzeResponseSchema.parse>;
+type AssignSlotsResult = ReturnType<typeof AssignSlotsResponseSchema.parse>;
+type GenerateResult = ReturnType<typeof GenerateResponseSchema.parse>;
+type VariantResult = ReturnType<typeof VariantResponseSchema.parse>;
+
+export interface ImageModelAdapter {
+  analyze(imageBase64: string, signal?: AbortSignal): Promise<AnalyzeResult>;
+  assignSlots(images: string[], signal?: AbortSignal): Promise<AssignSlotsResult>;
+  generate(params: {
+    shot: Shot;
+    slots: Partial<Record<InputSlot, string>>;
+    confirmedCategories: ClothingCategory[];
+    correctivePrompts: string[];
+    anchorImage?: string;
+  }, signal?: AbortSignal): Promise<GenerateResult>;
+  generateVariant(params: {
+    combination: VariantCombination;
+    anchorImage: string;
+    references: VariantReferences;
+  }, signal?: AbortSignal): Promise<VariantResult>;
+}

--- a/server/src/adapter/MockModelAdapter.ts
+++ b/server/src/adapter/MockModelAdapter.ts
@@ -1,0 +1,83 @@
+import crypto from "node:crypto";
+import {
+  AnalyzeResponseSchema,
+  AssignSlotsResponseSchema,
+  ClothingCategory,
+  GenerateResponseSchema,
+  InputSlot,
+  Shot,
+  VariantCombination,
+  VariantReferences,
+  VariantResponseSchema
+} from "../schemas";
+import { ImageModelAdapter } from "./ImageModelAdapter";
+
+const pickCategories = (imageBase64: string): ClothingCategory[] => {
+  const hash = crypto.createHash("sha256").update(imageBase64).digest();
+  const categories = Object.values(ClothingCategory);
+  const first = hash[0] % categories.length;
+  const second = hash[1] % categories.length;
+  const result = new Set<ClothingCategory>([categories[first], categories[second]]);
+  return Array.from(result);
+};
+
+const mapSlots = (images: string[]) => {
+  const keys = [InputSlot.FRONT, InputSlot.SIDE, InputSlot.BACK, InputSlot.DETAIL];
+  const entries = keys
+    .map((slot, index) => [slot, index] as const)
+    .filter(([, index]) => index < images.length);
+  return Object.fromEntries(entries) as Partial<Record<InputSlot, number>>;
+};
+
+const fakeBase64 = (seed: string) => Buffer.from(`Generated:${seed}`).toString("base64");
+
+export class MockModelAdapter implements ImageModelAdapter {
+  async analyze(imageBase64: string) {
+    const categories = pickCategories(imageBase64);
+    return AnalyzeResponseSchema.parse({
+      categories,
+      confidence: 0.9,
+      notes: "Mock classification"
+    });
+  }
+
+  async assignSlots(images: string[]) {
+    const slots = mapSlots(images);
+    return AssignSlotsResponseSchema.parse({ slots });
+  }
+
+  async generate(
+    params: {
+      shot: Shot;
+      slots: Partial<Record<InputSlot, string>>;
+      confirmedCategories: ClothingCategory[];
+      correctivePrompts: string[];
+      anchorImage?: string;
+    },
+    _signal?: AbortSignal
+  ) {
+    const payload = `${params.shot.description}:${params.confirmedCategories.join(",")}:${params.correctivePrompts.join(",")}`;
+    return GenerateResponseSchema.parse({ imageBase64: fakeBase64(payload) });
+  }
+
+  async generateVariant(
+    params: {
+      combination: VariantCombination;
+      anchorImage: string;
+      references: VariantReferences;
+    },
+    _signal?: AbortSignal
+  ) {
+    const imageBase64 = fakeBase64(
+      `${params.combination.name}:${Object.keys(params.references).join("-")}`
+    );
+    return VariantResponseSchema.parse([
+      {
+        imageBase64,
+        filename: `${params.combination.name.replace(/\s+/g, "_")}.jpg`,
+        products: Object.keys(params.references),
+        variantName: params.combination.name
+      }
+    ]);
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,53 @@
+import "dotenv/config";
+import express from "express";
+import cors from "cors";
+import { createApiRouter } from "./routes/api";
+import { GeminiModelAdapter } from "./adapter/GeminiModelAdapter";
+import { MockModelAdapter } from "./adapter/MockModelAdapter";
+import { ImageModelAdapter } from "./adapter/ImageModelAdapter";
+
+const PORT = Number(process.env.PORT ?? 3001);
+
+const createAdapter = (): ImageModelAdapter => {
+  const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    console.warn(
+      "GEMINI_API_KEY missing. Falling back to mock adapter; no external calls will be made."
+    );
+    return new MockModelAdapter();
+  }
+
+  try {
+    return new GeminiModelAdapter(apiKey);
+  } catch (error) {
+    console.error(
+      "Failed to initialize GeminiModelAdapter. Falling back to mock adapter.",
+      error
+    );
+    return new MockModelAdapter();
+  }
+};
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: "10mb" }));
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    console.log(`${req.method} ${req.originalUrl} ${res.statusCode} - ${duration}ms`);
+  });
+  next();
+});
+
+const adapter = createAdapter();
+app.use("/api", createApiRouter(adapter));
+
+app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error("API error", error);
+  res.status(500).json({ error: (error as Error).message ?? "Internal server error" });
+});
+
+app.listen(PORT, () => {
+  console.log(`AI Fashion Studio API listening on port ${PORT}`);
+});

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -1,0 +1,151 @@
+import express from "express";
+import { ImageModelAdapter } from "../adapter/ImageModelAdapter";
+import {
+  AnalyzeBodySchema,
+  AnalyzeResponseSchema,
+  AssignSlotsBodySchema,
+  AssignSlotsResponseSchema,
+  GenerateBodySchema,
+  GenerateResponseSchema,
+  QueueShotsBodySchema,
+  QueueShotsResponseSchema,
+  VariantsBodySchema,
+  VariantResponseSchema,
+  buildShotQueue
+} from "../schemas";
+import { generationQueue } from "../services/queue";
+import { retryWithBackoff } from "../services/retry";
+
+export const createApiRouter = (adapter: ImageModelAdapter) => {
+  const router = express.Router();
+
+  router.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  router.post("/analyze", async (req, res, next) => {
+    const parse = AnalyzeBodySchema.safeParse(req.body);
+    if (!parse.success) {
+      res.status(400).json({ error: parse.error.flatten() });
+      return;
+    }
+
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
+    try {
+      const response = await retryWithBackoff(() =>
+        adapter.analyze(parse.data.imageBase64, controller.signal)
+      );
+      res.json(AnalyzeResponseSchema.parse(response));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/assign-slots", async (req, res, next) => {
+    const parse = AssignSlotsBodySchema.safeParse(req.body);
+    if (!parse.success) {
+      res.status(400).json({ error: parse.error.flatten() });
+      return;
+    }
+
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
+    try {
+      const response = await retryWithBackoff(() =>
+        adapter.assignSlots(parse.data.images, controller.signal)
+      );
+      res.json(AssignSlotsResponseSchema.parse(response));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/queue-shots", async (req, res) => {
+    const parse = QueueShotsBodySchema.safeParse(req.body);
+    if (!parse.success) {
+      res.status(400).json({ error: parse.error.flatten() });
+      return;
+    }
+
+    const shots = buildShotQueue(parse.data.confirmed);
+    res.json(QueueShotsResponseSchema.parse({ shots }));
+  });
+
+  router.post("/generate", async (req, res, next) => {
+    const parse = GenerateBodySchema.safeParse(req.body);
+    if (!parse.success) {
+      res.status(400).json({ error: parse.error.flatten() });
+      return;
+    }
+
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
+    try {
+      const result = await generationQueue.add(
+        () =>
+          retryWithBackoff(() =>
+            adapter.generate(
+              {
+                shot: parse.data.shot,
+                slots: parse.data.slots ?? {},
+                confirmedCategories: parse.data.confirmedCategories,
+                correctivePrompts: parse.data.correctivePrompts,
+                anchorImage: parse.data.anchorImage
+              },
+              controller.signal
+            )
+          ),
+        { signal: controller.signal }
+      );
+
+      res.json(GenerateResponseSchema.parse(result));
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        res.status(499).json({ error: "Request aborted" });
+        return;
+      }
+      next(error);
+    }
+  });
+
+  router.post("/variants", async (req, res, next) => {
+    const parse = VariantsBodySchema.safeParse(req.body);
+    if (!parse.success) {
+      res.status(400).json({ error: parse.error.flatten() });
+      return;
+    }
+
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
+    try {
+      const response = await generationQueue.add(
+        () =>
+          retryWithBackoff(() =>
+            adapter.generateVariant(
+              {
+                combination: parse.data.combination,
+                anchorImage: parse.data.anchorImage,
+                references: parse.data.references ?? {}
+              },
+              controller.signal
+            )
+          ),
+        { signal: controller.signal }
+      );
+      res.json(VariantResponseSchema.parse(response));
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        res.status(499).json({ error: "Request aborted" });
+        return;
+      }
+      next(error);
+    }
+  });
+
+  return router;
+};

--- a/server/src/schemas.ts
+++ b/server/src/schemas.ts
@@ -1,0 +1,236 @@
+import { z } from "zod";
+
+export enum ClothingCategory {
+  TOP_SHORT_SLEEVE = "Top maniche corte",
+  TOP_LONG_SLEEVE = "Top maniche lunghe",
+  KNIT = "Maglia",
+  HOODIE = "Felpa",
+  JACKET = "Giacca",
+  PANTS = "Pantalone",
+  SKIRT = "Gonna",
+  DRESS = "Abito"
+}
+
+export const TOP_CATEGORIES = [
+  ClothingCategory.TOP_SHORT_SLEEVE,
+  ClothingCategory.TOP_LONG_SLEEVE,
+  ClothingCategory.KNIT,
+  ClothingCategory.HOODIE
+] as const;
+
+export const JACKET_CATEGORIES = [ClothingCategory.JACKET] as const;
+export const LOWER_BODY_CATEGORIES = [ClothingCategory.PANTS, ClothingCategory.SKIRT] as const;
+export const DRESS_CATEGORIES = [ClothingCategory.DRESS] as const;
+
+export const isTopCategory = (
+  category: ClothingCategory
+): category is (typeof TOP_CATEGORIES)[number] =>
+  (TOP_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isJacketCategory = (
+  category: ClothingCategory
+): category is (typeof JACKET_CATEGORIES)[number] =>
+  (JACKET_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isLowerBodyCategory = (
+  category: ClothingCategory
+): category is (typeof LOWER_BODY_CATEGORIES)[number] =>
+  (LOWER_BODY_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isDressCategory = (
+  category: ClothingCategory
+): category is (typeof DRESS_CATEGORIES)[number] =>
+  (DRESS_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export enum InputSlot {
+  FRONT = "front",
+  SIDE = "side",
+  BACK = "back",
+  DETAIL = "detail"
+}
+
+export enum ShotCategory {
+  FULL_BODY = "FULL_BODY",
+  UPPER_BODY_TOP = "UPPER_BODY_TOP",
+  UPPER_BODY_JACKET = "UPPER_BODY_JACKET",
+  LOWER_BODY = "LOWER_BODY",
+  DRESS = "DRESS",
+  DETAIL = "DETAIL"
+}
+
+type ProductGroup = "TOP" | "JACKET" | "LOWER_BODY" | "DRESS";
+
+const ProductGroupSchema = z.union([
+  z.literal("TOP"),
+  z.literal("JACKET"),
+  z.literal("LOWER_BODY"),
+  z.literal("DRESS")
+]);
+
+export const ShotSchema = z.object({
+  id: z.number().int(),
+  description: z.string(),
+  shot_category: z.nativeEnum(ShotCategory),
+  required_slots: z.array(z.nativeEnum(InputSlot)),
+  prompt_template: z.string(),
+  relevant_categories: z.array(ProductGroupSchema).optional()
+});
+
+export type Shot = z.infer<typeof ShotSchema>;
+
+export const AnalyzeBodySchema = z.object({
+  imageBase64: z.string().min(10)
+});
+
+export const AnalyzeResponseSchema = z.object({
+  categories: z.array(z.nativeEnum(ClothingCategory)),
+  confidence: z.number().min(0).max(1),
+  notes: z.string().optional()
+});
+
+export const AssignSlotsBodySchema = z.object({
+  images: z.array(z.string().min(10))
+});
+
+export const AssignSlotsResponseSchema = z.object({
+  slots: z
+    .record(z.nativeEnum(InputSlot), z.number().int().nonnegative())
+    .partial()
+});
+
+export const QueueShotsBodySchema = z.object({
+  confirmed: z.array(z.nativeEnum(ClothingCategory))
+});
+
+export const QueueShotsResponseSchema = z.object({
+  shots: z.array(ShotSchema)
+});
+
+export const GenerateBodySchema = z.object({
+  shot: ShotSchema,
+  slots: z.record(z.nativeEnum(InputSlot), z.string().min(10)).partial(),
+  confirmedCategories: z.array(z.nativeEnum(ClothingCategory)),
+  correctivePrompts: z.array(z.string()),
+  anchorImage: z.string().min(10).optional()
+});
+
+export const GenerateResponseSchema = z.object({
+  imageBase64: z.string().min(10)
+});
+
+export const VariantCombinationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  selection: z.record(ProductGroupSchema, z.string()).partial()
+});
+
+export type VariantCombination = z.infer<typeof VariantCombinationSchema>;
+
+export const VariantReferencesSchema = z
+  .record(z.nativeEnum(ClothingCategory), z.string().min(10))
+  .partial();
+
+export type VariantReferences = z.infer<typeof VariantReferencesSchema>;
+
+export const VariantsBodySchema = z.object({
+  combination: VariantCombinationSchema,
+  anchorImage: z.string().min(10),
+  references: VariantReferencesSchema
+});
+
+export const VariantResponseSchema = z.array(
+  z.object({
+    imageBase64: z.string().min(10),
+    filename: z.string(),
+    products: z.array(z.string()),
+    variantName: z.string().optional()
+  })
+);
+
+export const NEGATIVE_PROMPT =
+  "text watermark, distorted anatomy, duplicated limbs, asymmetric hands, incorrect brand logos, motion blur, over-smoothing, misaligned buttons, unrealistic textures";
+
+export const buildShotQueue = (confirmed: ClothingCategory[]): Shot[] => {
+  let shotId = 1;
+  const createShot = (shot: Omit<Shot, "id">): Shot => ({ id: shotId++, ...shot });
+
+  const queue: Shot[] = [];
+  const hasTop = confirmed.some((category) => isTopCategory(category));
+  const hasJacket = confirmed.some((category) => isJacketCategory(category));
+  const hasLowerBody = confirmed.some((category) => isLowerBodyCategory(category));
+  const hasDress = confirmed.some((category) => isDressCategory(category));
+
+  if ((hasTop && hasLowerBody) || hasDress) {
+    queue.push(
+      createShot({
+        description: "Full body front shot",
+        shot_category: ShotCategory.FULL_BODY,
+        required_slots: [InputSlot.FRONT],
+        prompt_template:
+          "Studio, soft directional light, neutral seamless background, premium editorial aesthetic. {reference_hint}. Negative prompt: {negative_prompt}",
+        relevant_categories: hasDress ? ["DRESS"] : ["TOP", "LOWER_BODY"]
+      })
+    );
+  }
+
+  if (hasTop || hasDress) {
+    queue.push(
+      createShot({
+        description: "Upper body focus",
+        shot_category: ShotCategory.UPPER_BODY_TOP,
+        required_slots: [InputSlot.FRONT],
+        prompt_template:
+          "Studio, soft directional light, neutral seamless background, premium editorial aesthetic. {reference_hint}. Negative prompt: {negative_prompt}",
+        relevant_categories: hasDress ? ["DRESS"] : ["TOP"]
+      })
+    );
+  }
+
+  if (hasJacket) {
+    queue.push(
+      createShot({
+        description: "Upper body jacket emphasis",
+        shot_category: ShotCategory.UPPER_BODY_JACKET,
+        required_slots: [InputSlot.FRONT, InputSlot.SIDE],
+        prompt_template:
+          "Studio, soft directional light, neutral seamless background, premium editorial aesthetic. {reference_hint}. Negative prompt: {negative_prompt}",
+        relevant_categories: ["JACKET"]
+      })
+    );
+  }
+
+  if (hasLowerBody || hasDress) {
+    queue.push(
+      createShot({
+        description: "Lower body detail",
+        shot_category: ShotCategory.LOWER_BODY,
+        required_slots: [InputSlot.FRONT, InputSlot.SIDE],
+        prompt_template:
+          "Studio, soft directional light, neutral seamless background, premium editorial aesthetic. {reference_hint}. Negative prompt: {negative_prompt}",
+        relevant_categories: hasDress ? ["DRESS"] : ["LOWER_BODY"]
+      })
+    );
+  }
+
+  const detailCount = hasJacket ? 3 : 2;
+  for (let index = 0; index < detailCount; index += 1) {
+    queue.push(
+      createShot({
+        description: `Detail shot ${index + 1}`,
+        shot_category: ShotCategory.DETAIL,
+        required_slots: [InputSlot.DETAIL],
+        prompt_template:
+          "Studio, soft directional light, neutral seamless background, premium editorial aesthetic. {reference_hint}. Negative prompt: {negative_prompt}",
+        relevant_categories: ["TOP", "JACKET", "LOWER_BODY", "DRESS"]
+      })
+    );
+  }
+
+  return queue.map((shot, index) => ({
+    ...shot,
+    prompt_template: shot.prompt_template
+      .replace("{reference_hint}", "Preserve the model identity, garment proportions, and background mood to match the anchor shot.")
+      .replace("{negative_prompt}", NEGATIVE_PROMPT)
+      .concat(` // Shot ${index + 1}`)
+  }));
+};

--- a/server/src/services/queue.ts
+++ b/server/src/services/queue.ts
@@ -1,0 +1,3 @@
+import PQueue from "p-queue";
+
+export const generationQueue = new PQueue({ concurrency: 3 });

--- a/server/src/services/retry.ts
+++ b/server/src/services/retry.ts
@@ -1,0 +1,18 @@
+export const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function retryWithBackoff<T>(fn: () => Promise<T>, attempts = 3) {
+  let delay = 250;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts - 1) break;
+      const jitter = Math.random() * 100;
+      await wait(delay + jitter);
+      delay *= 2;
+    }
+  }
+  throw lastError;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "lib": ["ES2021"],
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": false,
+    "outDir": "build",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build"]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Fashion Studio</title>
+  </head>
+  <body class="bg-slate-950 text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,6 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "class-variance-authority": "^0.7.0",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "nanoid": "^5.0.7",
@@ -18,8 +17,7 @@
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
     "zustand": "^4.5.2",
-    "zod": "^3.23.8",
-    "lucide-react": "^0.379.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/file-saver": "^2.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "file-saver": "^2.0.5",
+    "jszip": "^3.10.1",
+    "nanoid": "^5.0.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-dropzone": "^14.2.3",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "lucide-react": "^0.379.0"
+  },
+  "devDependencies": {
+    "@types/file-saver": "^2.0.7",
+    "@types/jszip": "^3.10.5",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.4.5",
+    "vite": "^5.3.1"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,99 @@
+import { Suspense, useEffect } from "react";
+import BulkUploader from "@/components/BulkUploader";
+import OutfitManager from "@/components/OutfitManager";
+import ColorVariantManager from "@/components/ColorVariantManager";
+import DownloadButtons from "@/components/DownloadButtons";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import { useOutfitStore } from "@/store/outfitStore";
+import { HealthResponse } from "@/types";
+
+const App = () => {
+  const outfits = useOutfitStore((state) => state.outfits);
+  const setBackendStatus = useOutfitStore((state) => state.setBackendStatus);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch("/api/health", { signal: controller.signal })
+      .then((response) => response.json() as Promise<HealthResponse>)
+      .then((data) => {
+        if (data.status === "ok") {
+          setBackendStatus("online");
+        } else {
+          setBackendStatus("degraded");
+        }
+      })
+      .catch(() => setBackendStatus("offline"));
+
+    return () => {
+      controller.abort();
+    };
+  }, [setBackendStatus]);
+
+  return (
+    <div className="min-h-screen text-slate-100">
+      <header className="border-b border-white/10 bg-slate-950/70 backdrop-blur sticky top-0 z-10">
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.2em] text-brand-400">
+              AI Fashion Studio
+            </p>
+            <h1 className="text-2xl font-semibold md:text-3xl">
+              Precisione, coerenza e varianti cromatiche per i tuoi outfit
+            </h1>
+          </div>
+          <div className="text-sm text-slate-300">
+            <p>Frontend React + Vite + Tailwind</p>
+            <p>Backend Node + Express</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-10">
+        <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl shadow-brand-500/10">
+          <h2 className="text-xl font-semibold text-brand-200">
+            Inizia caricando le immagini dell'outfit
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm text-slate-300">
+            Carica una o più immagini e lascia che il backend analizza categorie e
+            angolazioni. Puoi confermare o correggere rapidamente i risultati.
+          </p>
+          <div className="mt-6">
+            <ErrorBoundary>
+              <BulkUploader />
+            </ErrorBoundary>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-6">
+          {outfits.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-white/20 bg-slate-900/40 p-10 text-center text-slate-400">
+              <p className="text-lg font-medium">
+                Nessun outfit ancora. Carica immagini per iniziare a generare la
+                tua campagna.
+              </p>
+            </div>
+          ) : (
+            outfits.map((outfit) => (
+              <ErrorBoundary key={outfit.id}>
+                <Suspense fallback={<p>Caricamento gestione outfit…</p>}>
+                  <OutfitManager outfitId={outfit.id} />
+                </Suspense>
+              </ErrorBoundary>
+            ))
+          )}
+        </section>
+
+        <ErrorBoundary>
+          <ColorVariantManager />
+        </ErrorBoundary>
+
+        <ErrorBoundary>
+          <DownloadButtons />
+        </ErrorBoundary>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/web/src/components/BulkUploader.tsx
+++ b/web/src/components/BulkUploader.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useMemo, useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { nanoid } from "nanoid";
+import { analyzeOutfit, assignSlots } from "@/services/api";
+import {
+  ClothingCategory,
+  InputSlot,
+  OutfitStatus
+} from "@/types";
+import { createEmptyOutfit, useOutfitStore } from "@/store/outfitStore";
+
+const toBase64 = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result.split(",")[1] ?? result);
+      } else {
+        reject(new Error("Invalid file result"));
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+const useFileQueue = () => {
+  const [queue, setQueue] = useState<{ file: File; base64: string }[]>([]);
+
+  const enqueue = useCallback(async (files: File[]) => {
+    const conversions = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        base64: await toBase64(file)
+      }))
+    );
+    setQueue((current) => [...current, ...conversions]);
+    return conversions;
+  }, []);
+
+  const clear = useCallback(() => setQueue([]), []);
+
+  return { queue, enqueue, clear };
+};
+
+const BulkUploader = () => {
+  const { queue, enqueue, clear } = useFileQueue();
+  const addOutfit = useOutfitStore((state) => state.addOutfit);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      setIsProcessing(true);
+      setStatusMessage("Analisi delle immagini in corso…");
+      try {
+        const converted = await enqueue(acceptedFiles);
+        if (converted.length === 0) {
+          setStatusMessage("Nessun file valido");
+          return;
+        }
+
+        const primary = converted[0];
+        const analysis = await analyzeOutfit(primary.base64);
+        const autoConfirmed = analysis.confidence >= 0.85;
+        const categories = analysis.categories as ClothingCategory[];
+        const outfitId = nanoid();
+        const outfit = createEmptyOutfit({
+          id: outfitId,
+          name: `Outfit ${new Date().toLocaleTimeString()}`,
+          initialImage: primary.base64,
+          detectedCategories: categories,
+          confirmedCategories: autoConfirmed ? categories : undefined
+        });
+
+        addOutfit(outfit);
+
+        if (converted.length > 1) {
+          const slotAssignment = await assignSlots(
+            converted.map((item) => item.base64)
+          );
+
+          const slotEntries = Object.entries(slotAssignment.slots ?? {}) as [
+            InputSlot,
+            number
+          ][];
+          const slotImages: Partial<Record<InputSlot, string>> = {};
+          slotEntries.forEach(([slot, index]) => {
+            const candidate = converted[index];
+            if (candidate) {
+              slotImages[slot] = candidate.base64;
+            }
+          });
+
+          useOutfitStore.getState().updateSlots(outfitId, slotImages);
+        }
+
+        useOutfitStore
+          .getState()
+          .updateOutfit(outfitId, {
+            status: autoConfirmed
+              ? OutfitStatus.CATEGORIES_DETECTED
+              : OutfitStatus.COMPLETING_OUTFIT,
+            errorMessage: null
+          });
+
+        setStatusMessage(
+          autoConfirmed
+            ? "Categorie confermate automaticamente"
+            : "Verifica le categorie prima di procedere"
+        );
+      } catch (error) {
+        console.error("Upload error", error);
+        setStatusMessage("Impossibile analizzare le immagini. Riprova.");
+      } finally {
+        setIsProcessing(false);
+        clear();
+      }
+    },
+    [addOutfit, clear, enqueue]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "image/jpeg": [".jpeg", ".jpg"],
+      "image/png": [".png"],
+      "image/webp": [".webp"]
+    }
+  });
+
+  const queuedFiles = useMemo(
+    () => queue.map((item) => item.file.name).join(", "),
+    [queue]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div
+        {...getRootProps()}
+        className={`flex min-h-[180px] cursor-pointer flex-col items-center justify-center rounded-2xl border border-dashed border-brand-400/40 bg-slate-950/60 p-6 text-center transition ${
+          isDragActive ? "border-brand-300 bg-brand-500/10" : "hover:border-brand-300/70"
+        }`}
+      >
+        <input {...getInputProps()} />
+        <p className="text-lg font-semibold text-brand-200">
+          Trascina qui le immagini dell'outfit
+        </p>
+        <p className="mt-2 max-w-md text-sm text-slate-300">
+          Supportiamo scatti multipli: fronte, retro, laterale e dettagli. Il
+          sistema assegnerà automaticamente gli slot necessari.
+        </p>
+        {isProcessing && <p className="mt-4 animate-pulse">Analisi in corso…</p>}
+      </div>
+      {queuedFiles && (
+        <p className="text-xs text-slate-400">File in coda: {queuedFiles}</p>
+      )}
+      {statusMessage && (
+        <p className="text-sm text-brand-200">{statusMessage}</p>
+      )}
+    </div>
+  );
+};
+
+export default BulkUploader;

--- a/web/src/components/ColorVariantManager.tsx
+++ b/web/src/components/ColorVariantManager.tsx
@@ -1,0 +1,203 @@
+import { useMemo, useState } from "react";
+import { nanoid } from "nanoid";
+import {
+  ClothingCategory,
+  ColorVariantRequest,
+  GenerationCombination,
+  Outfit
+} from "@/types";
+import { useOutfitStore } from "@/store/outfitStore";
+
+const ColorVariantManager = () => {
+  const outfits = useOutfitStore((state) => state.outfits);
+  const setColorVariants = useOutfitStore((state) => state.setColorVariants);
+  const [selectedOutfitId, setSelectedOutfitId] = useState<string | null>(null);
+  const [variantName, setVariantName] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<ClothingCategory | "">("");
+  const [referenceImage, setReferenceImage] = useState<string>("");
+  const [combinations, setCombinations] = useState<GenerationCombination[]>([]);
+
+  const selectedOutfit = useMemo<Outfit | undefined>(
+    () => outfits.find((outfit) => outfit.id === (selectedOutfitId ?? "")),
+    [outfits, selectedOutfitId]
+  );
+
+  const requests = selectedOutfit?.colorVariantRequests ?? [];
+
+  const handleAddVariant = () => {
+    if (!variantName || !selectedOutfitId || !selectedCategory || !referenceImage) {
+      return;
+    }
+
+    const next: ColorVariantRequest = {
+      id: nanoid(),
+      name: variantName,
+      references: {
+        [selectedCategory]: referenceImage
+      }
+    };
+
+    const updated = [...requests, next];
+    setColorVariants(selectedOutfitId, {
+      requests: updated,
+      combinations: combinations.length > 0 ? combinations : selectedOutfit?.colorVariantCombinations ?? []
+    });
+    setVariantName("");
+    setSelectedCategory("");
+    setReferenceImage("");
+  };
+
+  const handleAddCombination = () => {
+    if (!selectedOutfitId) return;
+    const combination: GenerationCombination = {
+      id: nanoid(),
+      name: `Batch ${combinations.length + 1}`,
+      selection: {}
+    };
+    const next = [...combinations, combination];
+    setCombinations(next);
+    setColorVariants(selectedOutfitId, {
+      requests,
+      combinations: next
+    });
+  };
+
+  const convertFile = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result === "string") {
+          resolve(result.split(",")[1] ?? result);
+        } else {
+          reject(new Error("Invalid file result"));
+        }
+      };
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/50 p-6 shadow-xl shadow-brand-500/10">
+      <div className="flex flex-col gap-6 md:flex-row md:items-start">
+        <div className="md:w-1/3">
+          <h3 className="text-lg font-semibold text-brand-200">Varianti colore</h3>
+          <p className="mt-2 text-sm text-slate-300">
+            Definisci richieste colore partendo da riferimenti per ciascuna
+            categoria. Puoi poi combinare le varianti per creare batch di
+            generazione consistenti.
+          </p>
+          <select
+            value={selectedOutfitId ?? ""}
+            onChange={(event) => setSelectedOutfitId(event.target.value || null)}
+            className="mt-4 w-full rounded-xl border border-white/10 bg-slate-950/70 p-3 text-sm"
+          >
+            <option value="">Seleziona outfit</option>
+            {outfits.map((outfit) => (
+              <option value={outfit.id} key={outfit.id}>
+                {outfit.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1 space-y-6">
+          <div className="rounded-2xl border border-white/5 bg-slate-950/40 p-4">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Nuova variante colore
+            </h4>
+            <div className="mt-4 grid gap-4 md:grid-cols-3">
+              <input
+                value={variantName}
+                onChange={(event) => setVariantName(event.target.value)}
+                placeholder="Nome variante"
+                className="rounded-xl border border-white/10 bg-slate-900/70 p-3 text-sm text-slate-100"
+              />
+              <select
+                value={selectedCategory}
+                onChange={(event) =>
+                  setSelectedCategory(event.target.value as ClothingCategory | "")
+                }
+                className="rounded-xl border border-white/10 bg-slate-900/70 p-3 text-sm"
+              >
+                <option value="">Categoria</option>
+                {Object.values(ClothingCategory).map((category) => (
+                  <option value={category} key={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={async (event) => {
+                  const file = event.target.files?.[0];
+                  if (!file) return;
+                  const base64 = await convertFile(file);
+                  setReferenceImage(base64);
+                }}
+                className="rounded-xl border border-white/10 bg-slate-900/70 p-3 text-sm"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleAddVariant}
+              className="mt-4 rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-400"
+            >
+              Aggiungi variante
+            </button>
+          </div>
+
+          <div className="rounded-2xl border border-white/5 bg-slate-950/40 p-4">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Batch di generazione
+            </h4>
+            <button
+              type="button"
+              onClick={handleAddCombination}
+              className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-700"
+            >
+              Aggiungi batch
+            </button>
+            <div className="mt-4 space-y-3">
+              {(combinations.length > 0 ? combinations : selectedOutfit?.colorVariantCombinations ?? []).map(
+                (combination) => (
+                  <div
+                    key={combination.id}
+                    className="rounded-xl border border-white/10 bg-slate-900/60 p-3 text-sm"
+                  >
+                    <p className="font-semibold text-brand-200">{combination.name}</p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      {Object.entries(combination.selection).length > 0
+                        ? Object.entries(combination.selection)
+                            .map(([slot, value]) => `${slot}: ${value}`)
+                            .join(", ")
+                        : "Nessuna variante selezionata"}
+                    </p>
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+
+          {requests.length > 0 && (
+            <div className="rounded-2xl border border-white/5 bg-slate-950/40 p-4">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Varianti configurate
+              </h4>
+              <ul className="mt-3 space-y-2 text-sm text-slate-300">
+                {requests.map((request) => (
+                  <li key={request.id}>
+                    {request.name} — {Object.keys(request.references).join(", ")}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ColorVariantManager;

--- a/web/src/components/DownloadButtons.tsx
+++ b/web/src/components/DownloadButtons.tsx
@@ -1,0 +1,95 @@
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+import { useMemo, useState } from "react";
+import { useOutfitStore } from "@/store/outfitStore";
+import { GeneratedImage, Outfit } from "@/types";
+
+const createZipFromImages = async (images: GeneratedImage[], filename: string) => {
+  const zip = new JSZip();
+  images.forEach((image) => {
+    zip.file(`${image.filename}`, image.image, { base64: true });
+  });
+  const content = await zip.generateAsync({ type: "blob" });
+  saveAs(content, filename);
+};
+
+const DownloadButtons = () => {
+  const outfits = useOutfitStore((state) => state.outfits);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const groupedProducts = useMemo(() => {
+    const map = new Map<string, GeneratedImage[]>();
+    outfits.forEach((outfit) => {
+      outfit.generatedImages.forEach((image) => {
+        image.products.forEach((product) => {
+          const key = product;
+          const existing = map.get(key) ?? [];
+          existing.push(image);
+          map.set(key, existing);
+        });
+      });
+    });
+    return map;
+  }, [outfits]);
+
+  const handleDownloadAll = async () => {
+    setIsDownloading(true);
+    try {
+      const allImages = outfits.flatMap((outfit) => outfit.generatedImages);
+      if (allImages.length === 0) return;
+      await createZipFromImages(allImages, "AI-Fashion-Studio.zip");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleDownloadProduct = async (product: string) => {
+    const images = groupedProducts.get(product) ?? [];
+    if (images.length === 0) return;
+    setIsDownloading(true);
+    try {
+      await createZipFromImages(images, `${product}-AI-Fashion-Studio.zip`);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const renderedOutfits = outfits.filter((outfit: Outfit) => outfit.generatedImages.length > 0);
+
+  if (renderedOutfits.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl shadow-brand-500/10">
+      <h3 className="text-lg font-semibold text-brand-200">Download immagini</h3>
+      <p className="mt-2 text-sm text-slate-300">
+        Scarica tutte le immagini generate oppure crea pacchetti per singola
+        categoria prodotto.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleDownloadAll}
+          disabled={isDownloading}
+          className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-400 disabled:opacity-50"
+        >
+          Scarica tutto
+        </button>
+        {Array.from(groupedProducts.keys()).map((product) => (
+          <button
+            type="button"
+            key={product}
+            onClick={() => handleDownloadProduct(product)}
+            disabled={isDownloading}
+            className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-700 disabled:opacity-50"
+          >
+            {product}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default DownloadButtons;

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error?: Error;
+};
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-xl border border-rose-500/40 bg-rose-950/50 p-4 text-sm text-rose-100">
+          <p className="font-semibold">Si è verificato un errore imprevisto.</p>
+          <p className="mt-1 text-rose-200">
+            {this.state.error?.message ?? "Riprova più tardi."}
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/web/src/components/OutfitManager.tsx
+++ b/web/src/components/OutfitManager.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  ClothingCategory,
+  GeneratedImage,
+  InputSlot,
+  OutfitStatus,
+  Shot
+} from "@/types";
+import { useOutfitStore, toggleCategory } from "@/store/outfitStore";
+import { buildShotQueue } from "@/utils/shotBuilder";
+import { generateShot } from "@/services/api";
+import { mapGeneratedImage } from "@/utils/filename";
+
+const categoryLabels: Record<ClothingCategory, string> = {
+  [ClothingCategory.TOP_SHORT_SLEEVE]: "Top maniche corte",
+  [ClothingCategory.TOP_LONG_SLEEVE]: "Top maniche lunghe",
+  [ClothingCategory.KNIT]: "Maglia",
+  [ClothingCategory.HOODIE]: "Felpa",
+  [ClothingCategory.JACKET]: "Giacca",
+  [ClothingCategory.PANTS]: "Pantalone",
+  [ClothingCategory.SKIRT]: "Gonna",
+  [ClothingCategory.DRESS]: "Abito"
+};
+
+type OutfitManagerProps = {
+  outfitId: string;
+};
+
+type ShotState = {
+  shot: Shot;
+  status: "pending" | "generating" | "completed" | "error";
+  error?: string;
+  image?: GeneratedImage;
+};
+
+const OutfitManager = ({ outfitId }: OutfitManagerProps) => {
+  const outfit = useOutfitStore((state) =>
+    state.outfits.find((item) => item.id === outfitId)
+  );
+  const updateOutfit = useOutfitStore((state) => state.updateOutfit);
+  const enqueueShots = useOutfitStore((state) => state.enqueueShots);
+  const addGeneratedImage = useOutfitStore((state) => state.addGeneratedImage);
+  const [correctivePrompt, setCorrectivePrompt] = useState("");
+  const [localShotState, setLocalShotState] = useState<ShotState[]>([]);
+  const controllerRef = useRef<AbortController | null>(null);
+  const [isPaused, setIsPaused] = useState(false);
+  const pauseRef = useRef(false);
+
+  const confirmedCategories = useMemo(
+    () => Array.from(outfit?.confirmedCategories ?? []),
+    [outfit?.confirmedCategories]
+  );
+
+  const slotImages = outfit?.slots ?? {};
+
+  const handleToggle = useCallback(
+    (category: ClothingCategory) => {
+      if (!outfit) return;
+      const updated = toggleCategory(outfit, category);
+      updateOutfit(outfit.id, { confirmedCategories: updated });
+    },
+    [outfit, updateOutfit]
+  );
+
+  const ensureQueue = useCallback(async () => {
+    if (!outfit) return;
+    if (outfit.shotQueue.length === 0) {
+      await enqueueShots(outfit.id);
+    }
+  }, [enqueueShots, outfit]);
+
+  const refreshLocalShotState = useCallback(() => {
+    if (!outfit) return;
+    setLocalShotState(
+      outfit.shotQueue.map((shot) => ({
+        shot,
+        status: "pending" as const
+      }))
+    );
+  }, [outfit]);
+
+  const handleBuildQueue = useCallback(async () => {
+    if (!outfit) return;
+    if (outfit.shotQueue.length === 0) {
+      await enqueueShots(outfit.id);
+    } else {
+      const fallback = buildShotQueue(confirmedCategories);
+      useOutfitStore.getState().setShotQueue(outfit.id, fallback);
+    }
+    refreshLocalShotState();
+  }, [confirmedCategories, enqueueShots, outfit, refreshLocalShotState]);
+
+  const updateShotState = (shotId: number, update: Partial<ShotState>) => {
+    setLocalShotState((current) =>
+      current.map((item) =>
+        item.shot.id === shotId
+          ? {
+              ...item,
+              ...update
+            }
+          : item
+      )
+    );
+  };
+
+  const handleGenerate = useCallback(async () => {
+    if (!outfit || outfit.shotQueue.length === 0) {
+      await ensureQueue();
+    }
+
+    const currentOutfit = useOutfitStore
+      .getState()
+      .outfits.find((item) => item.id === outfitId);
+    if (!currentOutfit || currentOutfit.shotQueue.length === 0) return;
+
+    refreshLocalShotState();
+    setIsPaused(false);
+    pauseRef.current = false;
+
+    let anchorImage: string | undefined;
+    updateOutfit(outfitId, { status: OutfitStatus.GENERATING, errorMessage: null });
+
+    for (const shot of currentOutfit.shotQueue) {
+      if (pauseRef.current) break;
+      updateShotState(shot.id, { status: "generating" });
+
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      try {
+        const response = await generateShot(
+          {
+            shot,
+            slots: slotImages,
+            confirmedCategories,
+            correctivePrompts: correctivePrompt ? [correctivePrompt] : [],
+            anchorImage
+          },
+          controller.signal
+        );
+        const generated = mapGeneratedImage({
+          outfitIndex: 1,
+          shot,
+          imageBase64: response.imageBase64,
+          products: confirmedCategories,
+          variant: "original"
+        });
+        anchorImage = anchorImage ?? generated.image;
+        addGeneratedImage(outfitId, generated);
+        updateShotState(shot.id, { status: "completed", image: generated });
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          updateShotState(shot.id, { status: "pending" });
+          break;
+        }
+        updateShotState(shot.id, {
+          status: "error",
+          error: (error as Error).message
+        });
+        updateOutfit(outfitId, {
+          status: OutfitStatus.ERROR,
+          errorMessage: (error as Error).message
+        });
+        return;
+      } finally {
+        controllerRef.current = null;
+      }
+    }
+
+    if (!pauseRef.current) {
+      updateOutfit(outfitId, { status: OutfitStatus.COMPLETED });
+    }
+  }, [
+    addGeneratedImage,
+    confirmedCategories,
+    correctivePrompt,
+    ensureQueue,
+    outfit,
+    outfitId,
+    pauseRef,
+    refreshLocalShotState,
+    slotImages,
+    updateOutfit
+  ]);
+
+  const handlePause = () => {
+    setIsPaused(true);
+    pauseRef.current = true;
+    controllerRef.current?.abort();
+    updateOutfit(outfitId, { status: OutfitStatus.PAUSED });
+  };
+
+  const handleResume = () => {
+    setIsPaused(false);
+    pauseRef.current = false;
+    handleGenerate();
+  };
+
+  const handleCancel = () => {
+    controllerRef.current?.abort();
+    setIsPaused(false);
+    pauseRef.current = false;
+    updateOutfit(outfitId, { status: OutfitStatus.STOPPED });
+  };
+
+  if (!outfit) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-inner shadow-black/40">
+      <div className="flex flex-col gap-6 md:flex-row">
+        {outfit.initialImage ? (
+          <img
+            src={`data:image/jpeg;base64,${outfit.initialImage}`}
+            alt="Outfit"
+            className="h-48 w-48 rounded-xl object-cover"
+          />
+        ) : (
+          <div className="flex h-48 w-48 items-center justify-center rounded-xl bg-slate-950/60 text-sm text-slate-500">
+            Nessuna immagine iniziale
+          </div>
+        )}
+
+        <div className="flex-1 space-y-4">
+          <div>
+            <h3 className="text-lg font-semibold text-brand-200">Categorie</h3>
+            <p className="mt-1 text-xs text-slate-400">
+              Conferma o correggi le categorie rilevate per costruire la coda di
+              generazione.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {Object.values(ClothingCategory).map((category) => {
+                const isActive = outfit.confirmedCategories.has(category);
+                return (
+                  <button
+                    key={category}
+                    type="button"
+                    onClick={() => handleToggle(category)}
+                    className={`rounded-full px-4 py-2 text-xs font-semibold transition ${
+                      isActive
+                        ? "bg-brand-500 text-white shadow shadow-brand-500/50"
+                        : "bg-slate-800 text-slate-300 hover:bg-slate-700"
+                    }`}
+                  >
+                    {categoryLabels[category]}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            {Object.values(InputSlot).map((slot) => (
+              <div
+                key={slot}
+                className="rounded-xl border border-white/10 bg-slate-950/40 p-3 text-xs"
+              >
+                <p className="font-semibold uppercase tracking-wide text-brand-300">
+                  {slot}
+                </p>
+                {slotImages[slot] ? (
+                  <img
+                    src={`data:image/jpeg;base64,${slotImages[slot]}`}
+                    alt={slot}
+                    className="mt-2 h-24 w-full rounded-md object-cover"
+                  />
+                ) : (
+                  <p className="mt-2 text-slate-500">Nessuna immagine assegnata</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-slate-200">
+              Prompt correttivo (applicato ai prossimi scatti)
+            </label>
+            <textarea
+              value={correctivePrompt}
+              onChange={(event) => setCorrectivePrompt(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/50 p-3 text-sm text-slate-100"
+              placeholder="Es. enfatizza il tessuto, mantieni la postura naturale"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleBuildQueue}
+              className="rounded-full bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-700"
+            >
+              Costruisci coda scatti
+            </button>
+            <button
+              type="button"
+              onClick={handleGenerate}
+              className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-400"
+            >
+              Avvia generazione
+            </button>
+            <button
+              type="button"
+              onClick={handlePause}
+              className="rounded-full bg-amber-500/80 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-400"
+            >
+              Pausa
+            </button>
+            <button
+              type="button"
+              onClick={handleResume}
+              className="rounded-full bg-emerald-500/80 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-400"
+            >
+              Riprendi
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="rounded-full bg-rose-500/80 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-400"
+            >
+              Annulla
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-4">
+        <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+          Coda scatti
+        </h4>
+        <div className="grid gap-3 md:grid-cols-2">
+          {(localShotState.length > 0 ? localShotState : outfit.shotQueue.map((shot) => ({
+            shot,
+            status: "pending" as const
+          }))).map(({ shot, status, image, error }) => (
+            <div
+              key={shot.id}
+              className="rounded-2xl border border-white/5 bg-slate-950/40 p-4 text-sm"
+            >
+              <p className="font-semibold text-brand-200">{shot.description}</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Richiede: {shot.required_slots.join(", ")}
+              </p>
+              <p className="mt-2 text-xs uppercase tracking-wide text-slate-500">
+                Stato: {status}
+              </p>
+              {image && (
+                <img
+                  src={`data:image/jpeg;base64,${image.image}`}
+                  alt={shot.description}
+                  className="mt-2 h-32 w-full rounded-xl object-cover"
+                />
+              )}
+              {error && <p className="mt-2 text-xs text-rose-300">{error}</p>}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OutfitManager;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "@/App";
+import "@/styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+import {
+  ClothingCategory,
+  ColorVariantRequest,
+  GenerationCombination,
+  GeneratedImage,
+  InputSlot,
+  Outfit,
+  Shot
+} from "@/types";
+
+const AnalyzeResponseSchema = z.object({
+  categories: z.nativeEnum(ClothingCategory).array(),
+  confidence: z.number().min(0).max(1),
+  notes: z.string().optional()
+});
+
+export type AnalyzeResponse = z.infer<typeof AnalyzeResponseSchema>;
+
+const AssignSlotsResponseSchema = z.object({
+  slots: z.record(z.nativeEnum(InputSlot), z.number().int().nonnegative()).partial()
+});
+
+export type AssignSlotsResponse = z.infer<typeof AssignSlotsResponseSchema>;
+
+const QueueShotsResponseSchema = z.object({
+  shots: z
+    .object({
+      id: z.number().int(),
+      description: z.string(),
+      shot_category: z.string(),
+      required_slots: z.nativeEnum(InputSlot).array(),
+      prompt_template: z.string(),
+      relevant_categories: z.array(z.string()).optional()
+    })
+    .array()
+});
+
+export type QueueShotsResponse = z.infer<typeof QueueShotsResponseSchema>;
+
+const GenerateResponseSchema = z.object({
+  imageBase64: z.string().min(10)
+});
+
+export type GenerateResponse = z.infer<typeof GenerateResponseSchema>;
+
+const VariantResponseSchema = z.array(
+  z.object({
+    imageBase64: z.string().min(10),
+    filename: z.string().min(3),
+    products: z.array(z.string()),
+    variantName: z.string().optional()
+  })
+);
+
+export type VariantResponse = z.infer<typeof VariantResponseSchema>;
+
+const jsonHeaders = {
+  "Content-Type": "application/json"
+};
+
+export const analyzeOutfit = async (imageBase64: string) => {
+  const response = await fetch("/api/analyze", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ imageBase64 })
+  });
+
+  const json = await response.json();
+  return AnalyzeResponseSchema.parse(json);
+};
+
+export const assignSlots = async (images: string[]) => {
+  const response = await fetch("/api/assign-slots", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ images })
+  });
+  const json = await response.json();
+  return AssignSlotsResponseSchema.parse(json);
+};
+
+export const queueShots = async (confirmed: ClothingCategory[]) => {
+  const response = await fetch("/api/queue-shots", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ confirmed })
+  });
+  const json = await response.json();
+  return QueueShotsResponseSchema.parse(json).shots as Shot[];
+};
+
+export const generateShot = async (
+  payload: {
+    shot: Shot;
+    slots: Partial<Record<InputSlot, string>>;
+    confirmedCategories: ClothingCategory[];
+    correctivePrompts: string[];
+    anchorImage?: string;
+  },
+  signal?: AbortSignal
+) => {
+  const response = await fetch("/api/generate", {
+    method: "POST",
+    headers: jsonHeaders,
+    signal,
+    body: JSON.stringify(payload)
+  });
+  const json = await response.json();
+  return GenerateResponseSchema.parse(json);
+};
+
+export const generateVariants = async (
+  payload: {
+    combination: GenerationCombination;
+    anchorImage: string;
+    references: ColorVariantRequest["references"];
+  },
+  signal?: AbortSignal
+) => {
+  const response = await fetch("/api/variants", {
+    method: "POST",
+    headers: jsonHeaders,
+    signal,
+    body: JSON.stringify(payload)
+  });
+  const json = await response.json();
+  return VariantResponseSchema.parse(json) as GeneratedImage[];
+};
+
+export const persistOutfits = (outfits: Outfit[]) => {
+  localStorage.setItem("ai-fashion-studio:outfits:v1", JSON.stringify(outfits));
+};
+
+export const loadOutfits = (): Outfit[] => {
+  const raw = localStorage.getItem("ai-fashion-studio:outfits:v1");
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as Outfit[];
+    return parsed.map((outfit) => ({
+      ...outfit,
+      confirmedCategories: new Set(outfit.confirmedCategories)
+    }));
+  } catch (error) {
+    console.warn("Unable to parse persisted outfits", error);
+    return [];
+  }
+};

--- a/web/src/store/outfitStore.ts
+++ b/web/src/store/outfitStore.ts
@@ -1,0 +1,179 @@
+import { create } from "zustand";
+import {
+  ClothingCategory,
+  ColorVariantRequest,
+  GenerationCombination,
+  GeneratedImage,
+  InputSlot,
+  Outfit,
+  OutfitStatus,
+  Shot
+} from "@/types";
+import { queueShots } from "@/services/api";
+import { buildShotQueue } from "@/utils/shotBuilder";
+
+export type BackendStatus = "unknown" | "online" | "degraded" | "offline";
+
+export type OutfitStore = {
+  outfits: Outfit[];
+  backendStatus: BackendStatus;
+  addOutfit: (outfit: Outfit) => void;
+  updateOutfit: (id: string, update: Partial<Outfit>) => void;
+  setBackendStatus: (status: BackendStatus) => void;
+  enqueueShots: (id: string) => Promise<void>;
+  updateSlots: (id: string, slots: Partial<Record<InputSlot, string>>) => void;
+  addGeneratedImage: (id: string, image: GeneratedImage) => void;
+  setColorVariants: (
+    id: string,
+    data: {
+      requests: ColorVariantRequest[];
+      combinations: GenerationCombination[];
+    }
+  ) => void;
+  setShotQueue: (id: string, shots: Shot[]) => void;
+};
+
+const createOutfitUpdater = (set: (partial: (state: OutfitStore) => OutfitStore) => void) =>
+  (id: string, update: Partial<Outfit>) => {
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((outfit) =>
+        outfit.id === id
+          ? {
+              ...outfit,
+              ...update,
+              confirmedCategories: update.confirmedCategories
+                ? new Set(update.confirmedCategories)
+                : outfit.confirmedCategories
+            }
+          : outfit
+      )
+    }));
+  };
+
+export const useOutfitStore = create<OutfitStore>((set, get) => ({
+  outfits: [],
+  backendStatus: "unknown",
+  addOutfit: (outfit) =>
+    set((state) => ({
+      ...state,
+      outfits: [...state.outfits, outfit]
+    })),
+  updateOutfit: createOutfitUpdater(set),
+  setBackendStatus: (status) => set((state) => ({ ...state, backendStatus: status })),
+  enqueueShots: async (id: string) => {
+    const outfit = get().outfits.find((item) => item.id === id);
+    if (!outfit) return;
+
+    const confirmed = Array.from(outfit.confirmedCategories);
+    let shots = buildShotQueue(confirmed);
+
+    try {
+      const serverShots = await queueShots(confirmed);
+      shots = serverShots.length > 0 ? serverShots : shots;
+    } catch (error) {
+      console.warn("Falling back to client shot queue", error);
+    }
+
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              shotQueue: shots,
+              status: OutfitStatus.QUEUED
+            }
+          : item
+      )
+    }));
+  },
+  updateSlots: (id, slots) =>
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((outfit) =>
+        outfit.id === id
+          ? {
+              ...outfit,
+              slots: {
+                ...outfit.slots,
+                ...slots
+              }
+            }
+          : outfit
+      )
+    })),
+  addGeneratedImage: (id, image) =>
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((outfit) =>
+        outfit.id === id
+          ? {
+              ...outfit,
+              generatedImages: [...outfit.generatedImages, image]
+            }
+          : outfit
+      )
+    })),
+  setColorVariants: (id, data) =>
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((outfit) =>
+        outfit.id === id
+          ? {
+              ...outfit,
+              colorVariantRequests: data.requests,
+              colorVariantCombinations: data.combinations
+            }
+          : outfit
+      )
+    })),
+  setShotQueue: (id, shots) =>
+    set((state) => ({
+      ...state,
+      outfits: state.outfits.map((outfit) =>
+        outfit.id === id
+          ? {
+              ...outfit,
+              shotQueue: shots
+            }
+          : outfit
+      )
+    }))
+}));
+
+export const createEmptyOutfit = (params: {
+  id: string;
+  name: string;
+  initialImage: string | null;
+  detectedCategories: ClothingCategory[];
+  confirmedCategories?: Iterable<ClothingCategory>;
+}): Outfit => ({
+  id: params.id,
+  name: params.name,
+  status: OutfitStatus.CONFIGURING,
+  initialImage: params.initialImage,
+  detectedCategories: params.detectedCategories,
+  confirmedCategories: new Set(params.confirmedCategories ?? params.detectedCategories),
+  slots: {},
+  shotQueue: [],
+  currentShotIndex: 0,
+  generatedImages: [],
+  correctivePrompts: [],
+  errorMessage: null,
+  colorVariantStep: "idle",
+  colorVariantRequests: [],
+  colorVariantCombinations: [],
+  generatedColorVariants: {},
+  colorVariantError: null
+});
+
+export const toggleCategory = (outfit: Outfit, category: ClothingCategory) => {
+  const set = new Set(outfit.confirmedCategories);
+  if (set.has(category)) {
+    set.delete(category);
+  } else {
+    set.add(category);
+  }
+  return set;
+};

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e293b, #0f172a 60%);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,134 @@
+export enum ClothingCategory {
+  TOP_SHORT_SLEEVE = "Top maniche corte",
+  TOP_LONG_SLEEVE = "Top maniche lunghe",
+  KNIT = "Maglia",
+  HOODIE = "Felpa",
+  JACKET = "Giacca",
+  PANTS = "Pantalone",
+  SKIRT = "Gonna",
+  DRESS = "Abito"
+}
+
+export const TOP_CATEGORIES = [
+  ClothingCategory.TOP_SHORT_SLEEVE,
+  ClothingCategory.TOP_LONG_SLEEVE,
+  ClothingCategory.KNIT,
+  ClothingCategory.HOODIE
+] as const;
+
+export const JACKET_CATEGORIES = [ClothingCategory.JACKET] as const;
+
+export const LOWER_BODY_CATEGORIES = [
+  ClothingCategory.PANTS,
+  ClothingCategory.SKIRT
+] as const;
+
+export const DRESS_CATEGORIES = [ClothingCategory.DRESS] as const;
+
+export const isTopCategory = (
+  category: ClothingCategory
+): category is (typeof TOP_CATEGORIES)[number] =>
+  (TOP_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isJacketCategory = (
+  category: ClothingCategory
+): category is (typeof JACKET_CATEGORIES)[number] =>
+  (JACKET_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isLowerBodyCategory = (
+  category: ClothingCategory
+): category is (typeof LOWER_BODY_CATEGORIES)[number] =>
+  (LOWER_BODY_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export const isDressCategory = (
+  category: ClothingCategory
+): category is (typeof DRESS_CATEGORIES)[number] =>
+  (DRESS_CATEGORIES as readonly ClothingCategory[]).includes(category);
+
+export enum InputSlot {
+  FRONT = "front",
+  SIDE = "side",
+  BACK = "back",
+  DETAIL = "detail"
+}
+
+export enum ShotCategory {
+  FULL_BODY = "FULL_BODY",
+  UPPER_BODY_TOP = "UPPER_BODY_TOP",
+  UPPER_BODY_JACKET = "UPPER_BODY_JACKET",
+  LOWER_BODY = "LOWER_BODY",
+  DRESS = "DRESS",
+  DETAIL = "DETAIL"
+}
+
+type ProductGroup = "TOP" | "JACKET" | "LOWER_BODY" | "DRESS";
+
+export type Shot = {
+  id: number;
+  description: string;
+  shot_category: ShotCategory;
+  required_slots: InputSlot[];
+  prompt_template: string;
+  relevant_categories?: ProductGroup[];
+};
+
+export type GeneratedImage = {
+  id_prompt: number;
+  image: string;
+  filename: string;
+  products: string[];
+  variantName?: string;
+};
+
+export type ColorVariantRequest = {
+  id: string;
+  name: string;
+  references: Partial<Record<ClothingCategory, string>>;
+};
+
+export type GenerationCombination = {
+  id: string;
+  name: string;
+  selection: Partial<Record<ProductGroup, string>>;
+};
+
+export enum OutfitStatus {
+  CONFIGURING = "CONFIGURING",
+  ANALYZING = "ANALYZING",
+  COMPLETING_OUTFIT = "COMPLETING_OUTFIT",
+  CATEGORIES_DETECTED = "CATEGORIES_DETECTED",
+  QUEUED = "QUEUED",
+  GENERATING = "GENERATING",
+  PAUSED = "PAUSED",
+  COMPLETED = "COMPLETED",
+  STOPPED = "STOPPED",
+  ERROR = "ERROR"
+}
+
+export type Outfit = {
+  id: string;
+  name: string;
+  status: OutfitStatus;
+  initialImage: string | null;
+  detectedCategories: ClothingCategory[];
+  confirmedCategories: Set<ClothingCategory>;
+  slots: Partial<Record<InputSlot, string>>;
+  shotQueue: Shot[];
+  currentShotIndex: number;
+  generatedImages: GeneratedImage[];
+  correctivePrompts: string[];
+  errorMessage: string | null;
+  colorVariantStep: "idle" | "configuring" | "generating" | "completed" | "error";
+  colorVariantRequests: ColorVariantRequest[];
+  colorVariantCombinations: GenerationCombination[];
+  generatedColorVariants: Record<string, GeneratedImage[]>;
+  colorVariantError: string | null;
+};
+
+export const enum StorageKeys {
+  OUTFITS = "ai-fashion-studio:outfits:v1"
+}
+
+export type HealthResponse = {
+  status: "ok";
+};

--- a/web/src/utils/filename.ts
+++ b/web/src/utils/filename.ts
@@ -1,0 +1,37 @@
+import { GeneratedImage, Shot } from "@/types";
+
+const pad = (value: number) => value.toString().padStart(2, "0");
+
+export const buildFilename = (params: {
+  outfitIndex: number;
+  shot: Shot;
+  products: string[];
+  variant?: string;
+}): string => {
+  const slug = params.shot.description
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+
+  const variant = params.variant ?? "original";
+  const productsSlug = params.products
+    .map((product) => product.replace(/\s+/g, "-"))
+    .join("-")
+    .toLowerCase();
+
+  return `OUTFIT-${pad(params.outfitIndex)}_${pad(params.shot.id)}-${slug}_${productsSlug}_${variant}.jpg`;
+};
+
+export const mapGeneratedImage = (params: {
+  outfitIndex: number;
+  shot: Shot;
+  imageBase64: string;
+  products: string[];
+  variant?: string;
+}): GeneratedImage => ({
+  id_prompt: params.shot.id,
+  image: params.imageBase64,
+  filename: buildFilename(params),
+  products: params.products,
+  variantName: params.variant
+});

--- a/web/src/utils/prompts.ts
+++ b/web/src/utils/prompts.ts
@@ -1,0 +1,11 @@
+export const NEGATIVE_PROMPT =
+  "text watermark, distorted anatomy, duplicated limbs, asymmetric hands, incorrect brand logos, motion blur, over-smoothing, misaligned buttons, unrealistic textures";
+
+export const composePrompt = (base: string, extras?: string[]) => {
+  const segments = [base, "Studio, soft directional lighting", "Neutral gradient background"];
+  if (extras && extras.length > 0) {
+    segments.push(...extras);
+  }
+  segments.push(`Negative prompt: ${NEGATIVE_PROMPT}`);
+  return segments.join(", ");
+};

--- a/web/src/utils/shotBuilder.ts
+++ b/web/src/utils/shotBuilder.ts
@@ -1,0 +1,111 @@
+import {
+  ClothingCategory,
+  InputSlot,
+  Shot,
+  ShotCategory,
+  isDressCategory,
+  isJacketCategory,
+  isLowerBodyCategory,
+  isTopCategory
+} from "@/types";
+
+let shotIdCounter = 1;
+
+const promptBase =
+  "Studio, soft directional light, neutral seamless background, premium editorial aesthetic.";
+const referenceHint =
+  "Preserve the model identity, garment proportions, and background mood to match the anchor shot.";
+const negativePrompt =
+  "NEGATIVE_PROMPT: text watermark, disfigured limbs, extra arms, missing fingers, distorted fabric, incorrect logos, motion blur, deformed feet, duplicated garments";
+
+const nextShotId = () => shotIdCounter++;
+
+const createShot = (params: Omit<Shot, "id">): Shot => ({
+  id: nextShotId(),
+  ...params
+});
+
+export const resetShotCounter = () => {
+  shotIdCounter = 1;
+};
+
+export const buildShotQueue = (confirmed: ClothingCategory[]): Shot[] => {
+  resetShotCounter();
+  const queue: Shot[] = [];
+  const hasTop = confirmed.some((category) => isTopCategory(category));
+  const hasJacket = confirmed.some((category) => isJacketCategory(category));
+  const hasLowerBody = confirmed.some((category) => isLowerBodyCategory(category));
+  const hasDress = confirmed.some((category) => isDressCategory(category));
+
+  if ((hasTop && hasLowerBody) || hasDress) {
+    queue.push(
+      createShot({
+        description: "Full body front shot",
+        shot_category: ShotCategory.FULL_BODY,
+        required_slots: [InputSlot.FRONT],
+        prompt_template: `${promptBase} {model_style}, ${referenceHint}. {reference_hint}. {negative_prompt}`,
+        relevant_categories: hasDress ? ["DRESS"] : ["TOP", "LOWER_BODY"]
+      })
+    );
+  }
+
+  if (hasTop || hasDress) {
+    queue.push(
+      createShot({
+        description: "Upper body focus",
+        shot_category: ShotCategory.UPPER_BODY_TOP,
+        required_slots: [InputSlot.FRONT],
+        prompt_template: `${promptBase} Tight composition highlighting upper garment. {reference_hint}. {negative_prompt}`,
+        relevant_categories: hasDress ? ["DRESS"] : ["TOP"]
+      })
+    );
+  }
+
+  if (hasJacket) {
+    queue.push(
+      createShot({
+        description: "Upper body jacket emphasis",
+        shot_category: ShotCategory.UPPER_BODY_JACKET,
+        required_slots: [InputSlot.FRONT, InputSlot.SIDE],
+        prompt_template: `${promptBase} Showcase jacket structure and detailing. {reference_hint}. {negative_prompt}`,
+        relevant_categories: ["JACKET"]
+      })
+    );
+  }
+
+  if (hasLowerBody || hasDress) {
+    queue.push(
+      createShot({
+        description: "Lower body detail",
+        shot_category: ShotCategory.LOWER_BODY,
+        required_slots: [InputSlot.FRONT, InputSlot.SIDE],
+        prompt_template: `${promptBase} Focus on lower garment drape and fit. {reference_hint}. {negative_prompt}`,
+        relevant_categories: hasDress ? ["DRESS"] : ["LOWER_BODY"]
+      })
+    );
+  }
+
+  const detailShotsCount = hasJacket ? 3 : 2;
+  for (let index = 0; index < detailShotsCount; index += 1) {
+    queue.push(
+      createShot({
+        description: `Detail shot ${index + 1}`,
+        shot_category: ShotCategory.DETAIL,
+        required_slots: [InputSlot.DETAIL],
+        prompt_template: `${promptBase} Macro detail of fabric and finishing. {reference_hint}. {negative_prompt}`,
+        relevant_categories: ["TOP", "JACKET", "LOWER_BODY", "DRESS"]
+      })
+    );
+  }
+
+  return queue.map((shot, shotIndex) => ({
+    ...shot,
+    prompt_template: shot.prompt_template
+      .replace("{reference_hint}", referenceHint)
+      .replace("{negative_prompt}", negativePrompt)
+      .replace("{model_style}", "Premium editorial model, confident pose")
+      .replace("{lighting}", "Soft studio lighting")
+      .replace("{background_style}", "Neutral gradient backdrop")
+      .replace("{shotIndex}", String(shotIndex + 1))
+  }));
+};

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: "#f4f5ff",
+          100: "#e5e7ff",
+          200: "#d0d5ff",
+          300: "#aab4ff",
+          400: "#7c86ff",
+          500: "#5c64ff",
+          600: "#434bdb",
+          700: "#3339ab",
+          800: "#232879",
+          900: "#171b4f"
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/web/tsconfig.base.json
+++ b/web/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src")
+    }
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- rename the web and server workspace package names so pnpm filters match the folder aliases
- allow the documented `pnpm --filter web dev` and `pnpm --filter server dev` commands to resolve in any environment

## Testing
- `pnpm --filter server exec pwd`
- `pnpm --filter web exec pwd`


------
https://chatgpt.com/codex/tasks/task_e_68d3d64597e48332b2ad968b6b78bf50