### PR TITLE
Fix local storage persistence to prevent blank screen

### DIFF
--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -137,6 +137,43 @@ type PersistedOutfit = Omit<Outfit, "confirmedCategories"> & {
 const isBrowserEnvironment =
   typeof window !== "undefined" && typeof window.localStorage !== "undefined";
 
+const safeGetItem = (key: StorageKeys): string | null => {
+  if (!isBrowserEnvironment) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn("Unable to read from localStorage", error);
+    return null;
+  }
+};
+
+const safeSetItem = (key: StorageKeys, value: string) => {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn("Unable to write to localStorage", error);
+  }
+};
+
+const safeRemoveItem = (key: StorageKeys) => {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.warn("Unable to remove localStorage item", error);
+  }
+};
+
 const validCategories = new Set(Object.values(ClothingCategory));
 
 const toCategoryArray = (value: unknown): ClothingCategory[] => {
@@ -207,7 +244,7 @@ export const persistOutfits = (outfits: Outfit[]) => {
     confirmedCategories: Array.from(outfit.confirmedCategories)
   }));
 
-  window.localStorage.setItem(StorageKeys.OUTFITS, JSON.stringify(serializable));
+  safeSetItem(StorageKeys.OUTFITS, JSON.stringify(serializable));
 };
 
 export const loadOutfits = (): Outfit[] => {
@@ -215,7 +252,7 @@ export const loadOutfits = (): Outfit[] => {
     return [];
   }
 
-  const raw = window.localStorage.getItem(StorageKeys.OUTFITS);
+  const raw = safeGetItem(StorageKeys.OUTFITS);
   if (!raw) {
     return [];
   }
@@ -255,6 +292,7 @@ export const loadOutfits = (): Outfit[] => {
       }));
   } catch (error) {
     console.warn("Unable to parse persisted outfits", error);
+    safeRemoveItem(StorageKeys.OUTFITS);
     return [];
   }
 };

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -6,7 +6,9 @@ import {
   GeneratedImage,
   InputSlot,
   Outfit,
-  Shot
+  Shot,
+  StorageKeys,
+  OutfitStatus
 } from "@/types";
 
 const AnalyzeResponseSchema = z.object({
@@ -128,19 +130,129 @@ export const generateVariants = async (
   return VariantResponseSchema.parse(json) as GeneratedImage[];
 };
 
+type PersistedOutfit = Omit<Outfit, "confirmedCategories"> & {
+  confirmedCategories: ClothingCategory[];
+};
+
+const isBrowserEnvironment =
+  typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+const validCategories = new Set(Object.values(ClothingCategory));
+
+const toCategoryArray = (value: unknown): ClothingCategory[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is ClothingCategory =>
+    validCategories.has(item as ClothingCategory)
+  );
+};
+
+const sanitizeSlots = (
+  value: unknown
+): Partial<Record<InputSlot, string>> => {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const slotEntries = Object.entries(value as Record<string, unknown>);
+  const slotSet = new Set(Object.values(InputSlot));
+
+  return Object.fromEntries(
+    slotEntries.filter(
+      ([key, slotValue]) => slotSet.has(key as InputSlot) && typeof slotValue === "string"
+    )
+  ) as Partial<Record<InputSlot, string>>;
+};
+
+const isValidOutfitStatus = (value: unknown): value is OutfitStatus =>
+  typeof value === "string" && Object.values(OutfitStatus).includes(value as OutfitStatus);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const validColorVariantSteps = new Set<Outfit["colorVariantStep"]>([
+  "idle",
+  "configuring",
+  "generating",
+  "completed",
+  "error"
+]);
+
+const toColorVariantStep = (value: unknown): Outfit["colorVariantStep"] =>
+  typeof value === "string" && validColorVariantSteps.has(value as Outfit["colorVariantStep"])
+    ? (value as Outfit["colorVariantStep"])
+    : "idle";
+
+const sanitizeGeneratedColorVariants = (
+  value: unknown
+): Record<string, GeneratedImage[]> => {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([, images]) => Array.isArray(images))
+  ) as Record<string, GeneratedImage[]>;
+};
+
 export const persistOutfits = (outfits: Outfit[]) => {
-  localStorage.setItem("ai-fashion-studio:outfits:v1", JSON.stringify(outfits));
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  const serializable: PersistedOutfit[] = outfits.map((outfit) => ({
+    ...outfit,
+    confirmedCategories: Array.from(outfit.confirmedCategories)
+  }));
+
+  window.localStorage.setItem(StorageKeys.OUTFITS, JSON.stringify(serializable));
 };
 
 export const loadOutfits = (): Outfit[] => {
-  const raw = localStorage.getItem("ai-fashion-studio:outfits:v1");
-  if (!raw) return [];
+  if (!isBrowserEnvironment) {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(StorageKeys.OUTFITS);
+  if (!raw) {
+    return [];
+  }
+
   try {
-    const parsed = JSON.parse(raw) as Outfit[];
-    return parsed.map((outfit) => ({
-      ...outfit,
-      confirmedCategories: new Set(outfit.confirmedCategories)
-    }));
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter((item): item is PersistedOutfit => isRecord(item))
+      .map((outfit) => ({
+        ...outfit,
+        status: isValidOutfitStatus(outfit.status) ? outfit.status : OutfitStatus.CONFIGURING,
+        detectedCategories: toCategoryArray(outfit.detectedCategories),
+        confirmedCategories: new Set(toCategoryArray(outfit.confirmedCategories)),
+        slots: sanitizeSlots(outfit.slots),
+        shotQueue: Array.isArray(outfit.shotQueue) ? outfit.shotQueue : [],
+        currentShotIndex:
+          typeof outfit.currentShotIndex === "number" ? outfit.currentShotIndex : 0,
+        generatedImages: Array.isArray(outfit.generatedImages) ? outfit.generatedImages : [],
+        correctivePrompts: Array.isArray(outfit.correctivePrompts)
+          ? outfit.correctivePrompts
+          : [],
+        errorMessage: typeof outfit.errorMessage === "string" ? outfit.errorMessage : null,
+        colorVariantStep: toColorVariantStep(outfit.colorVariantStep),
+        colorVariantRequests: Array.isArray(outfit.colorVariantRequests)
+          ? outfit.colorVariantRequests
+          : [],
+        colorVariantCombinations: Array.isArray(outfit.colorVariantCombinations)
+          ? outfit.colorVariantCombinations
+          : [],
+        generatedColorVariants: sanitizeGeneratedColorVariants(outfit.generatedColorVariants),
+        colorVariantError:
+          typeof outfit.colorVariantError === "string" ? outfit.colorVariantError : null
+      }));
   } catch (error) {
     console.warn("Unable to parse persisted outfits", error);
     return [];

--- a/web/src/store/outfitStore.ts
+++ b/web/src/store/outfitStore.ts
@@ -9,7 +9,7 @@ import {
   OutfitStatus,
   Shot
 } from "@/types";
-import { queueShots } from "@/services/api";
+import { queueShots, loadOutfits, persistOutfits } from "@/services/api";
 import { buildShotQueue } from "@/utils/shotBuilder";
 
 export type BackendStatus = "unknown" | "online" | "degraded" | "offline";
@@ -33,9 +33,11 @@ export type OutfitStore = {
   setShotQueue: (id: string, shots: Shot[]) => void;
 };
 
-const createOutfitUpdater = (set: (partial: (state: OutfitStore) => OutfitStore) => void) =>
+const createOutfitUpdater = (
+  setWithPersist: (updater: (state: OutfitStore) => OutfitStore) => void
+) =>
   (id: string, update: Partial<Outfit>) => {
-    set((state) => ({
+    setWithPersist((state) => ({
       ...state,
       outfits: state.outfits.map((outfit) =>
         outfit.id === id
@@ -51,96 +53,106 @@ const createOutfitUpdater = (set: (partial: (state: OutfitStore) => OutfitStore)
     }));
   };
 
-export const useOutfitStore = create<OutfitStore>((set, get) => ({
-  outfits: [],
-  backendStatus: "unknown",
-  addOutfit: (outfit) =>
-    set((state) => ({
-      ...state,
-      outfits: [...state.outfits, outfit]
-    })),
-  updateOutfit: createOutfitUpdater(set),
-  setBackendStatus: (status) => set((state) => ({ ...state, backendStatus: status })),
-  enqueueShots: async (id: string) => {
-    const outfit = get().outfits.find((item) => item.id === id);
-    if (!outfit) return;
+export const useOutfitStore = create<OutfitStore>((set, get) => {
+  const setWithPersist = (updater: (state: OutfitStore) => OutfitStore) => {
+    set((state) => {
+      const nextState = updater(state);
+      persistOutfits(nextState.outfits);
+      return nextState;
+    });
+  };
 
-    const confirmed = Array.from(outfit.confirmedCategories);
-    let shots = buildShotQueue(confirmed);
+  return {
+    outfits: loadOutfits(),
+    backendStatus: "unknown",
+    addOutfit: (outfit) =>
+      setWithPersist((state) => ({
+        ...state,
+        outfits: [...state.outfits, outfit]
+      })),
+    updateOutfit: createOutfitUpdater(setWithPersist),
+    setBackendStatus: (status) => set((state) => ({ ...state, backendStatus: status })),
+    enqueueShots: async (id: string) => {
+      const outfit = get().outfits.find((item) => item.id === id);
+      if (!outfit) return;
 
-    try {
-      const serverShots = await queueShots(confirmed);
-      shots = serverShots.length > 0 ? serverShots : shots;
-    } catch (error) {
-      console.warn("Falling back to client shot queue", error);
-    }
+      const confirmed = Array.from(outfit.confirmedCategories);
+      let shots = buildShotQueue(confirmed);
 
-    set((state) => ({
-      ...state,
-      outfits: state.outfits.map((item) =>
-        item.id === id
-          ? {
-              ...item,
-              shotQueue: shots,
-              status: OutfitStatus.QUEUED
-            }
-          : item
-      )
-    }));
-  },
-  updateSlots: (id, slots) =>
-    set((state) => ({
-      ...state,
-      outfits: state.outfits.map((outfit) =>
-        outfit.id === id
-          ? {
-              ...outfit,
-              slots: {
-                ...outfit.slots,
-                ...slots
+      try {
+        const serverShots = await queueShots(confirmed);
+        shots = serverShots.length > 0 ? serverShots : shots;
+      } catch (error) {
+        console.warn("Falling back to client shot queue", error);
+      }
+
+      setWithPersist((state) => ({
+        ...state,
+        outfits: state.outfits.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                shotQueue: shots,
+                status: OutfitStatus.QUEUED
               }
-            }
-          : outfit
-      )
-    })),
-  addGeneratedImage: (id, image) =>
-    set((state) => ({
-      ...state,
-      outfits: state.outfits.map((outfit) =>
-        outfit.id === id
-          ? {
-              ...outfit,
-              generatedImages: [...outfit.generatedImages, image]
-            }
-          : outfit
-      )
-    })),
-  setColorVariants: (id, data) =>
-    set((state) => ({
-      ...state,
-      outfits: state.outfits.map((outfit) =>
-        outfit.id === id
-          ? {
-              ...outfit,
-              colorVariantRequests: data.requests,
-              colorVariantCombinations: data.combinations
-            }
-          : outfit
-      )
-    })),
-  setShotQueue: (id, shots) =>
-    set((state) => ({
-      ...state,
-      outfits: state.outfits.map((outfit) =>
-        outfit.id === id
-          ? {
-              ...outfit,
-              shotQueue: shots
-            }
-          : outfit
-      )
-    }))
-}));
+            : item
+        )
+      }));
+    },
+    updateSlots: (id, slots) =>
+      setWithPersist((state) => ({
+        ...state,
+        outfits: state.outfits.map((outfit) =>
+          outfit.id === id
+            ? {
+                ...outfit,
+                slots: {
+                  ...outfit.slots,
+                  ...slots
+                }
+              }
+            : outfit
+        )
+      })),
+    addGeneratedImage: (id, image) =>
+      setWithPersist((state) => ({
+        ...state,
+        outfits: state.outfits.map((outfit) =>
+          outfit.id === id
+            ? {
+                ...outfit,
+                generatedImages: [...outfit.generatedImages, image]
+              }
+            : outfit
+        )
+      })),
+    setColorVariants: (id, data) =>
+      setWithPersist((state) => ({
+        ...state,
+        outfits: state.outfits.map((outfit) =>
+          outfit.id === id
+            ? {
+                ...outfit,
+                colorVariantRequests: data.requests,
+                colorVariantCombinations: data.combinations
+              }
+            : outfit
+        )
+      })),
+    setShotQueue: (id, shots) =>
+      setWithPersist((state) => ({
+        ...state,
+        outfits: state.outfits.map((outfit) =>
+          outfit.id === id
+            ? {
+                ...outfit,
+                shotQueue: shots
+              }
+            : outfit
+        )
+      }))
+  };
+});
 
 export const createEmptyOutfit = (params: {
   id: string;


### PR DESCRIPTION
## Summary
- serialize outfits before persisting so Sets and other fields are stored safely and only when `localStorage` is available
- load outfits from storage with validation, rebuilding Sets and default values to avoid runtime crashes from malformed data
- wire the Zustand store to hydrate from saved outfits and persist every mutation so the UI no longer boots to a blank screen

## Testing
- `pnpm --filter ai-fashion-studio-web lint` *(fails: missing dependencies because the sandbox cannot reach the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f4e494bc8332b1789a50074dce75